### PR TITLE
v0.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_AUTOMOC ON)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-find_package(Qt6 6.6.0 REQUIRED COMPONENTS Core Gui Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
 find_package(protobuf REQUIRED CONFIG)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/example/mainwindow.h
+++ b/example/mainwindow.h
@@ -31,15 +31,21 @@ private:
     void save_as();
     void internal_save(std::string file);
     void open();
+    void close();
+    void clear();
     std::string getFileName(QFileDialog::FileMode mode);
 
-    std::string _associatedFileName = "";
+    void initMenuBar();
+
+    std::optional<std::string> _associatedFileName = {};
+
+    int _fps;
 
     Ui::MainWindow *ui;
     qtgraph::WCanvas *_canvas;
     QTimer *_timer;
 
-    QAction *_openTypes, *_save, *_saveAs, *_open, *_snapping;
+    QAction *_openTypes, *_save, *_saveAs, *_open, *_close, *_snapping, *_clear;
     QMenu *_menuFile, *_menuOptions;
     QMenuBar *_menuBar;
 };

--- a/include/private/logics/graph.h
+++ b/include/private/logics/graph.h
@@ -43,6 +43,7 @@ public:
     const QMultiMap<IPinData, IPinData> &getConnections() const { return _connectedPins; }
 
     void removeNode(uint32_t nodeID);
+    void clear();
     bool connectPins(IPinData in, IPinData out);
     void disconnectPins(IPinData in, IPinData out);
 

--- a/include/private/widgets/canvas.h
+++ b/include/private/widgets/canvas.h
@@ -97,6 +97,7 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 private slots:
+    void onLNodeRemoved(uint32_t id);
     void onNodeSelect(bool bIsMultiSelectionModifierDown, uint32_t nodeID);
     void onPinDrag(IPinDragSignal signal);
     void onPinConnect(IPinData outPin, IPinData inPin);

--- a/include/private/widgets/canvas.h
+++ b/include/private/widgets/canvas.h
@@ -51,6 +51,7 @@ public:
     void setSnappingEnabled(bool enabled) { _bIsSnappingEnabled = enabled; }
     void toggleSnapping() { _bIsSnappingEnabled = !_bIsSnappingEnabled; }
     void setSnappingInterval(int num) { _snappingInterval = num; }
+    void clear();
     inline void moveView(QVector2D vector) { moveCanvas(QPointF(-vector.x(), -vector.y())); }
     inline void moveViewUp(float by) { moveCanvas(QPointF(0, by)); }
     inline void moveViewDown(float by) { moveCanvas(QPointF(0, -by)); }

--- a/src/logics/graph.cpp
+++ b/src/logics/graph.cpp
@@ -52,6 +52,8 @@ bool LGraph::deserialize(std::fstream *input)
 
 bool LGraph::deprotocolize(protocol::Graph &graph)
 {
+
+
     protocol::State state = graph.state();
     if (state.has_node_type_manager())
         setNodeTypeManager(NodeTypeManager::fromProtocolTypeManager(state.node_type_manager()));
@@ -140,6 +142,15 @@ bool LGraph::readStructure(const protocol::Structure &structure)
 // ---------------------- GENERAL FUNCTIONS ---------------------------
 
 
+void LGraph::clear()
+{
+    std::ranges::for_each(_nodes, [](LNode *node){
+        delete node;
+    });
+    _nodes.clear();
+    _connectedPins.clear();
+}
+
 QString LGraph::getPinText(uint32_t nodeID, uint32_t pinID) const
 {
     return _nodes[nodeID]->pin(pinID).value()->getText();
@@ -169,7 +180,7 @@ void LGraph::removeNode(uint32_t nodeID)
             });
         });
     }
-    delete _nodes[nodeID];
+    delete ptr;
     _nodes.remove(nodeID);
 }
 

--- a/src/logics/graph.cpp
+++ b/src/logics/graph.cpp
@@ -52,7 +52,7 @@ bool LGraph::deserialize(std::fstream *input)
 
 bool LGraph::deprotocolize(protocol::Graph &graph)
 {
-
+    clear();
 
     protocol::State state = graph.state();
     if (state.has_node_type_manager())

--- a/src/widgets/canvas.cpp
+++ b/src/widgets/canvas.cpp
@@ -138,6 +138,12 @@ void WCanvas::visualize()
 // ---------------------- GENERAL FUNCTIONS ---------------------------
 
 
+void WCanvas::clear()
+{ 
+    getGraph()->clear(); 
+    _offset = QPointF(0, 0);
+}
+
 void WCanvas::moveCanvasOnPinDragNearEdge(QPointF mousePosition)
 {
     auto lerp = [&](float actual, float max) {
@@ -362,7 +368,7 @@ void WCanvas::onLNodeRemoved(uint32_t id)
     _nodes.remove(id);
     if (_selectedNodes.contains(id)) 
         _selectedNodes.remove(id);
-        
+
     delete ptr;
     onNodeRemoved(id);
 }

--- a/src/widgets/canvas.cpp
+++ b/src/widgets/canvas.cpp
@@ -52,11 +52,7 @@ WCanvas::WCanvas(QWidget *parent)
     _typeBrowser->show();
 
     connect(_typeBrowser, &TypeBrowser::onMove, this, &WCanvas::onTypeBrowserMove);
-    connect(_graph, &LGraph::onNodeRemoved, this, [this](uint32_t id){
-        delete _nodes[id];
-        _nodes.remove(id);
-        onNodeRemoved(id);
-    });
+    connect(_graph, &LGraph::onNodeRemoved, this, &WCanvas::onLNodeRemoved);
 
     _timer = new QTimer(this);
     connect(_timer, &QTimer::timeout, this, &WCanvas::tick);
@@ -360,6 +356,17 @@ LNode *WCanvas::addNode(QPoint canvasPosition, int typeID)
     return addNode(node);
 }
 
+void WCanvas::onLNodeRemoved(uint32_t id)
+{
+    WANode *ptr = _nodes[id];
+    _nodes.remove(id);
+    if (_selectedNodes.contains(id)) 
+        _selectedNodes.remove(id);
+        
+    delete ptr;
+    onNodeRemoved(id);
+}
+
 
 // --------------------------- EVENTS ----------------------------------
 
@@ -367,12 +374,9 @@ LNode *WCanvas::addNode(QPoint canvasPosition, int typeID)
 void WCanvas::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Delete && !_selectedNodes.isEmpty())
-    {
         std::ranges::for_each(_selectedNodes, [&](WANode *ptr){ 
             _graph->removeNode(ptr->ID());
         });
-        _selectedNodes.clear();
-    }
 
     QWidget::keyPressEvent(event);
 }

--- a/src/widgets/canvas.cpp
+++ b/src/widgets/canvas.cpp
@@ -103,6 +103,9 @@ bool WCanvas::serialize(std::fstream *output) const
 bool WCanvas::deserialize(std::fstream *input)
 {
     setUpdatesEnabled(false);
+
+    clear();
+
     protocol::Graph graph;
     graph.ParseFromIstream(input);
 

--- a/src/widgets/typebrowser.cpp
+++ b/src/widgets/typebrowser.cpp
@@ -87,6 +87,11 @@ void TypeBrowser::clear()
         child = _layout->takeAt(0);
         delete child;
     }
+    
+    std::ranges::for_each(_nodeImages, [&](TypedNodeImage *img){
+        delete img;
+    });
+    _nodeImages.clear();
 
     _layout->addSpacing(c_typeBrowserSpacing);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(QtGraph)
 
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -24,11 +26,13 @@ qt_add_executable(tests
     main.cpp
     tst_main.cpp
     tst_protobuf.cpp    
+    tst_graph.cpp
 )
 
 target_link_libraries(tests PRIVATE
     gtest_main
     QtGraph
+    Qt6::Test
 )
 
 target_include_directories(tests 

--- a/tests/tst_graph.cpp
+++ b/tests/tst_graph.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+#include <QtGraph/LGraph>
+#include <QSignalSpy>
+
+using namespace testing;
+using namespace qtgraph;
+
+class TestGraph : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        graph = new LGraph();
+
+        auto *node1 = graph->addNode(QPoint(0,0), "Node 1");
+        auto *node2 = graph->addNode(QPoint(-100, -100), "Node 2");
+        uint32_t pin1 = node1->addPin("Pin 1", EPinDirection::In);
+        uint32_t pin2 = node2->addPin("Pin 2", EPinDirection::Out);
+
+        graph->connectPins(node1->pin(pin1).value()->getData(), node2->pin(pin2).value()->getData()); 
+    }
+
+    void TearDown() override
+    {
+        delete graph;
+    }
+
+    LGraph *graph;
+};
+
+
+TEST_F(TestGraph, Clear)
+{
+    graph->clear();
+    EXPECT_FALSE(graph->containsNode(0));
+    EXPECT_TRUE(graph->getConnections().empty());
+}
+
+TEST_F(TestGraph, NodeRemoved)
+{
+    QSignalSpy spy(graph, &LGraph::onNodeRemoved);
+    graph->removeNode(0);
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/tst_main.cpp
+++ b/tests/tst_main.cpp
@@ -42,7 +42,7 @@ protected:
 
 
 
-TEST(PinData, ByteArrayConversions)
+TEST(IPinData, ByteArrayConversions)
 {
     IPinData first(EPinDirection::In, 5, 6);
     QByteArray arr = first.toByteArray();
@@ -55,7 +55,7 @@ TEST(PinData, ByteArrayConversions)
     EXPECT_EQ(first, second);
 }
 
-TEST(NodeSpawnData, ByteArrayConversions)
+TEST(INodeSpawnData, ByteArrayConversions)
 {
     QString str("Text");
     INodeSpawnData first(str);
@@ -69,7 +69,7 @@ TEST(NodeSpawnData, ByteArrayConversions)
     EXPECT_EQ(third, fourth);
 }
 
-TEST(Utility, Snapping)
+TEST(Utilities, Snapping)
 {
     auto pointToString = [](QPoint point) {
         return std::to_string(point.x()) + ", " + std::to_string(point.y());
@@ -95,42 +95,7 @@ TEST(Utility, Snapping)
     });
 }
 
-TEST(Utility, IDGeneration)
-{
-    IDGenerator gen;
-    EXPECT_EQ(0, gen.generate());
-    EXPECT_EQ(1, gen.generate());
-    EXPECT_EQ(2, gen.generate());
-    gen.removeTaken(1);
-    EXPECT_EQ(1, gen.generate());
-    EXPECT_EQ(3, gen.generate());
-    gen = IDGenerator(std::set({ 0U, 1U, 2U, 3U, 4U, 5U, 6U }));
-    EXPECT_EQ(7, gen.generate());
-    gen.removeTaken(4);
-    EXPECT_EQ(4, gen.generate());
-    gen.removeTaken(0);
-    EXPECT_EQ(0, gen.generate());
-}
-
-TEST_F(TypeManagers, JsonParsing)
-{
-    int node_types = 6;
-    int pin_types = 5;
-
-    EXPECT_EQ(node_types, _NodeTypeManager.Types().size()) << "Expected " << node_types << " and got " << _NodeTypeManager.Types().size() << " node types.";
-    EXPECT_EQ(pin_types, _PinTypeManager.Types().size()) << "Expected " << pin_types << " and got " << _PinTypeManager.Types().size() << " pin types.";
-}
-
-TEST_F(TypeManagers, Properties)
-{
-    EXPECT_EQ("power", _PinTypeManager.Types().at(0).value("name").toString());
-    EXPECT_EQ(0, _PinTypeManager.TypeNames()["power"]);
-
-    EXPECT_EQ("Socket", _NodeTypeManager.Types().at(0).value("name").toString());
-    EXPECT_EQ(0, _NodeTypeManager.TypeNames()["Socket"]);
-}
-
-TEST(NodeFactory, ParseToColor)
+TEST(Utilities, ParseToColor)
 {
     auto check = [](QString str, int r, int g, int b) {
         QColor clr = parseToColor(str);
@@ -150,3 +115,37 @@ TEST(NodeFactory, ParseToColor)
     check(str3, 0xFF, 0xFF, 0xFF);
 }
 
+TEST(IDGenerator, General)
+{
+    IDGenerator gen;
+    EXPECT_EQ(0, gen.generate());
+    EXPECT_EQ(1, gen.generate());
+    EXPECT_EQ(2, gen.generate());
+    gen.removeTaken(1);
+    EXPECT_EQ(1, gen.generate());
+    EXPECT_EQ(3, gen.generate());
+    gen = IDGenerator(std::set({ 0U, 1U, 2U, 3U, 4U, 5U, 6U }));
+    EXPECT_EQ(7, gen.generate());
+    gen.removeTaken(4);
+    EXPECT_EQ(4, gen.generate());
+    gen.removeTaken(0);
+    EXPECT_EQ(0, gen.generate());
+}
+
+TEST_F(TypeManagers, ParseJSON)
+{
+    int node_types = 6;
+    int pin_types = 5;
+
+    EXPECT_EQ(node_types, _NodeTypeManager.Types().size()) << "Expected " << node_types << " and got " << _NodeTypeManager.Types().size() << " node types.";
+    EXPECT_EQ(pin_types, _PinTypeManager.Types().size()) << "Expected " << pin_types << " and got " << _PinTypeManager.Types().size() << " pin types.";
+}
+
+TEST_F(TypeManagers, Properties)
+{
+    EXPECT_EQ("power", _PinTypeManager.Types().at(0).value("name").toString());
+    EXPECT_EQ(0, _PinTypeManager.TypeNames()["power"]);
+
+    EXPECT_EQ("Socket", _NodeTypeManager.Types().at(0).value("name").toString());
+    EXPECT_EQ(0, _NodeTypeManager.TypeNames()["Socket"]);
+}

--- a/tests/tst_protobuf.cpp
+++ b/tests/tst_protobuf.cpp
@@ -18,34 +18,41 @@ using google::protobuf::util::MessageDifferencer;
 
 class Protocolization : public ::testing::Test
 {
-protected:
+public:
     Protocolization() {}
-    void SetUp() override 
+    static void SetUpTestSuite()
     {
-        graph = new LGraph();
-        auto node1 = graph->addNode(QPoint(0, 10), "Node");
-        auto node2 = graph->addNode(QPoint(100, 100), "Node");
+        initial = new LGraph();
+        auto node1 = initial->addNode(QPoint(0, 10), "Node");
+        auto node2 = initial->addNode(QPoint(100, 100), "Node");
         node1_id = node1->ID();
         node2_id = node2->ID();
         pin1_id = node1->addPin("pin1", EPinDirection::Out);
         pin2_id = node2->addPin("pin2", EPinDirection::In);
         IPinData pin1_data = node1->pin(pin1_id).value()->getData();
         IPinData pin2_data = node2->pin(pin2_id).value()->getData();
-        ASSERT_TRUE(graph->connectPins(pin1_data, pin2_data)) << "Couldn't add connection";
-        structure = graph->getConnections();
-        file = "test_protocolization.graph";
+        ASSERT_TRUE(initial->connectPins(pin1_data, pin2_data)) << "Couldn't add connection";
+        file = "test_protocolization.initial";
     }
 
-    void TearDown() override
+    static void TearDownTestSuite()
     {
-        delete graph;
+        delete initial;
+        delete deserialized;
     }
 
-    LGraph *graph;
-    std::string file;
-    uint32_t node1_id, node2_id, pin1_id, pin2_id;
-    QMultiMap<IPinData, IPinData> structure;
+    static LGraph *initial;
+    static LGraph *deserialized;
+    static std::string file;
+    static uint32_t node1_id, node2_id, pin1_id, pin2_id;
 };
+
+LGraph *Protocolization::initial = new LGraph();
+LGraph *Protocolization::deserialized = new LGraph();
+
+std::string Protocolization::file = std::string();
+uint32_t Protocolization::node1_id = 0, Protocolization::node2_id = 0, Protocolization::pin1_id = 0, Protocolization::pin2_id = 0;
+
 
 TEST_F(Protocolization, PinDirectionCompatibility)
 {
@@ -58,37 +65,35 @@ TEST_F(Protocolization, Serialization)
 {
     std::fstream out(file, std::ios::out | std::ios::trunc | std::ios::binary);
     ASSERT_TRUE(out.is_open());
-    EXPECT_TRUE(graph->serialize(&out));
+    EXPECT_TRUE(initial->serialize(&out));
 }
 
 TEST_F(Protocolization, Deserialization)
 {
-    delete graph;
-    graph = new LGraph();
-
     std::fstream in(file, std::ios::in | std::ios::binary);
     ASSERT_TRUE(in.is_open());
-    EXPECT_TRUE(graph->deserialize(&in));
+    EXPECT_TRUE(deserialized->deserialize(&in));
 }
 
 TEST_F(Protocolization, NodesData)
 {
-    EXPECT_EQ(graph->getNodeName(node1_id), "Node");
-    EXPECT_EQ(graph->getNodeName(node2_id), "Node");
+    EXPECT_EQ(deserialized->getNodeName(node1_id), "Node");
+    EXPECT_EQ(deserialized->getNodeName(node2_id), "Node");
 }
 
 TEST_F(Protocolization, PinsData)
 {
-    EXPECT_EQ(graph->getPinText(node1_id, pin1_id), "pin1");
+    EXPECT_EQ(deserialized->getPinText(node1_id, pin1_id), "pin1");
 }
 
 TEST_F(Protocolization, StructureData)
 {
-    const auto &deserialized = graph->getConnections();
+    const auto &deserializedStructure = deserialized->getConnections();
+    const auto &initialStructure = initial->getConnections();
 
-    ASSERT_EQ(deserialized.size(), structure.size());
+    ASSERT_EQ(deserializedStructure.size(), initialStructure.size());
     
-    std::ranges::for_each(deserialized.asKeyValueRange(), [&](std::pair<const IPinData&, const IPinData&> pair){
-        EXPECT_TRUE(structure.contains(pair.first, pair.second));
+    std::ranges::for_each(deserializedStructure.asKeyValueRange(), [&](std::pair<const IPinData&, const IPinData&> pair){
+        EXPECT_TRUE(initialStructure.contains(pair.first, pair.second));
     });
 }


### PR DESCRIPTION
Adds new actions into example
Fixes and updates tests
Adds missing logic for opening a saved graph while there are nodes on the canvas (in the graph):
1. Graph and canvas are cleared
2. The TypeBrowser now correctly reloads (or loads) types